### PR TITLE
fix(package): update gatsby-transformer-remark to version 1.7.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gatsby-plugin-sharp": "1.6.46",
     "gatsby-plugin-styled-components": "2.0.11",
     "gatsby-source-filesystem": "1.5.38",
-    "gatsby-transformer-remark": "1.7.41",
+    "gatsby-transformer-remark": "1.7.43",
     "gatsby-transformer-sharp": "1.6.26",
     "react-helmet": "^5.2.0",
     "styled-components": "3.3.0"


### PR DESCRIPTION
Closes #409

